### PR TITLE
Change needed for a local build of ffmpeg-kit.arr

### DIFF
--- a/flutter/test-app-local-dependency/android/app/build.gradle
+++ b/flutter/test-app-local-dependency/android/app/build.gradle
@@ -62,4 +62,8 @@ flutter {
 
 dependencies {
     testImplementation 'junit:junit:4.13.2'
+
+    // Needed for a local build of ffmpeg-kit.arr
+    implementation 'com.arthenica:smart-exception-java:0.2.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
 }


### PR DESCRIPTION
## Description
I found these dependencies to be necessary, or else I got all sorts of strange errors like "Unhandled Exception: PlatformException(channel-error, Unable to establish connection on channel., null, null)"

NOTE: for local ffmpeg-kit.arr to work, there is another pull request needed on ffmpeg-kit/flutter. This change doesn't break anything, though.

## Type of Change
- Bug fix

## Platform
Android/flutter

## Checks
- [no] Breaks existing functionality
- [yes] Implementation is completed, not half-done 
- [no] Is there another PR already created for this feature/bug fix

## Tests
`flutter run` on linux host. 